### PR TITLE
feat: use replacement as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ entire branch name.
 
 
 * `gitPrefix.patternIgnoreCase`: Ignore case in pattern.  Default is `false`.
+* `gitPrefix.replacementIsAFunction`: If true, the replacement string is a function where parameters (p1, p2, p3, etc.) are corresponding with the matching patterns $1, $2, $3, etc.. Default is false.
+  > Example : (p1, p2, p3, p4) => p1 + (p3 ? `(${p2}): ${p4.replace(/-/g, ' ')}` : p2.replace(/-/g, ' '))
 * `gitPrefix.replacement`: Regular expression replacement string to place into commit message. Default is `"[$1] "`.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -409,13 +409,24 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://code.bestbuy.com/artifactory/api/npm/npm-virtual/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				}
 			}
 		},
 		"inflight": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
 					"default": false,
 					"description": "Ignore case in pattern."
 				},
+				"gitPrefix.replacementIsAFunction": {
+					"type": "boolean",
+					"default": false,
+					"description": "Replacement string is a function witch parameters are the matching patterns."
+				},
 				"gitPrefix.replacement": {
 					"type": "string",
 					"default": "[$1] ",


### PR DESCRIPTION
My branches use the naming pattern described [here](https://www.conventionalcommits.org/en/v1.0.0/). Moreover, they use dashes instead of spaces. So I need a more powerful replacement feature. 