### PR TITLE
Autofocus the commit message text field

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,7 @@ async function prefixCommit (repository: Repository) {
       ticket = branchName.replace(branchRegEx, prefixReplacement)
     }
     repository.inputBox.value = `${ticket}${repository.inputBox.value}`
+    focusInputBox()
   } else {
     const message = `Pattern ${prefixPattern} not found in branch ${branchName}`
     const editPattern = 'Edit Pattern'
@@ -63,6 +64,10 @@ async function prefixCommit (repository: Repository) {
       vscode.commands.executeCommand('settings.action.clearSearchResults')
     }
   }
+}
+
+function focusInputBox () {
+  vscode.commands.executeCommand('workbench.scm.focus')
 }
 
 function getGitExtension () {


### PR DESCRIPTION
Hi I really like your extension and use it very frequently. As I found it a little bit annoying to refocus the input field for the git commit message, I fixed it as described in issue #7.

## Result

Now one can continue typing the commit message after running the prefix command:

<img src="https://user-images.githubusercontent.com/12248527/143243432-eafa3bff-a069-4c64-8261-0bfb18950021.gif" alt="Preview" width="100%"/>

Closes #7