### PR TITLE
Fix usage of rootUri path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate (context: vscode.ExtensionContext) {
 
     if (uri) {
       const selectedRepository = git.repositories.find(repository => {
-        return repository.rootUri.path === uri._rootUri.path
+        return repository.rootUri.path === uri.rootUri.path
       })
 
       if (selectedRepository) {


### PR DESCRIPTION
Hi @srmeyers,

I've found a fix for #22. It's quite easy, just seemed to be that `rootUri` is now a public property without the underscore anymore. Now it works pretty good again:

![preview](https://user-images.githubusercontent.com/12248527/206701749-03a3107f-7b54-4ea3-88ab-780902d30054.gif)
