### PR TITLE
Fix Issue #29

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,11 @@ async function prefixCommit (repository: Repository) {
     const currentMessage = repository.inputBox.value.split(ticket).join('');
 
     repository.inputBox.value = isSuffix ? `${currentMessage}${ticket}` : `${ticket}${currentMessage}`
-    vscode.commands.executeCommand("list.focusFirst");
-    vscode.commands.executeCommand("list.select");
+
+    if (vscode.workspace.workspaceFolders?.length === 1) {
+      vscode.commands.executeCommand("list.focusFirst");
+      vscode.commands.executeCommand("list.select");
+    }
   } else {
     const message = `Pattern ${pattern} not found in branch ${branchName}`
     const editPattern = 'Edit Pattern'


### PR DESCRIPTION
Original Issue https://github.com/srmeyers/git-prefix/issues/29 states that the source control folder collapses if more than two folders are active.


I added an IF statement so that when only one folder is active, the selection works as expected and selects the textBox
But if more than one folder is active in the source control tab it will not do this and keep the state of the collapsable folders.